### PR TITLE
feat : 유기동물 복합 조건 필터링 검색

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,54 +1,70 @@
 ### 📌 PR 개요
 <!-- 이 PR이 어떤 기능/수정/버그패치인지 간략하게 설명해주세요 -->
-유저 프로필 기반 반려동물 등록 및 조회 기능을 구현하였습니다.
+ElasticSearch를 통한 유기동물 복합 조건 검색을 구현하였습니다.
 
 ---
 
 ### 🔨 작업 내용 요약
 <!-- 주요 변경사항을 bullet 형식으로 요약해 주세요 -->
-- 기능 추가: 로그인된 유저의 반려동물 등록 API (`POST /api/pet/enroll`)
-- 기능 추가: 유저 프로필의 반려동물 목록 조회 API (`GET /api/pet/profile/pets`)
-- 기능 개선: `PetService`에서 DTO → Entity 변환 및 연관관계 설정
-- 리팩토링: `UserService`에서 인증 유저 정보 기반 조회 로직 정리
-
+- 기능 추가: 로그인된 유저의 유기동물 복합 조건 검색 API (`GET /api/abandoned/abandoned-pets/search`)
+- 🔄 전체 흐름
+  1. Controller(`AbandonedPetController`)에서 검색 조건(`type`, `location`, `foundDate`)을 Query Parameter로 전달받음
+  2. Service(`AbandonedPetSearchService`)에서 조건에 맞게 Elasticsearch DSL 쿼리를 동적으로 구성
+  3. `ElasticsearchClient`를 사용해 검색 요청 수행
+  4. 검색된 결과를 `AbandonedPetDocument` 리스트로 매핑하여 반환
+- 🔍 검색 조건 및 쿼리 DSL 구성
+  - 사용자가 입력한 조건은 모두 **AND 조건**(`bool.must`)으로 적용됨
+  - 조건이 없으면 `match_all` 쿼리를 사용하여 전체 데이터를 조회함
+  - 각 필드별 검색 방식은 다음과 같음:
+    - `type`, `foundDate`: `Keyword` 타입이므로 `term` 쿼리 사용
+    - `location`: `Text` 타입이므로 `match` 쿼리 사용
+  - 예시 DSL 구조:
+    ```json
+    {
+      "bool": {
+        "must": [
+          { "term": { "type": "비숑" } },
+          { "match": { "location": "인천" } },
+          { "term": { "foundDate": "2025-07-09" } }
+        ]
+      }
+    }
+    ```
 ---
+
 
 ### ✅ 상세 구현 내용
 <!-- 상세하게 어떤 작업을 했는지 설명해주세요 -->
-- `@AuthenticationPrincipal`을 활용하여 로그인된 유저의 userId를 기반으로 반려동물 등록
-  - `PetProfileDto`를 받아 `Pet` Entity로 변환한 후 `User`와 연관지어 저장
-- 반려동물 등록 시 `userRepository.findByUserId()`로 유저 식별 및 연관관계 설정
-- 반려동물 목록 조회 시 `petRepository.findByUserUserId()` 메서드를 통해 해당 유저의 반려동물 조회
-  - `Pet` Entity 리스트를 `PetProfileDto` 리스트로 변환 후 반환
-- API 보안 강화를 위해 `/api/pet/**` 경로는 `SecurityConfig`에서 인증된 사용자만 접근 가능하도록 설정
+- Elasticsearch Java API Client를 활용하여 유기동물 복합 조건 검색 기능 구현
+- 검색 조건: 품종(`type`), 발견 장소(`location`), 발견 날짜(`foundDate`)를 기반으로 검색 가능
+  - `type`, `foundDate` 필드는 `Keyword` 타입 → `term` 쿼리 사용
+  - `location` 필드는 `Text` 타입 → `match` 쿼리 사용
+- 검색 조건은 선택적으로 입력할 수 있도록 구성 (AND 조건)
+  - 조건이 하나도 없을 경우, 전체 데이터를 `match_all` 쿼리로 조회
+- 검색 쿼리는 `BoolQuery`를 구성하여 `must` 절에 조건별 `Query` 추가
+- 검색 결과는 `AbandonedPetDocument` 클래스로 매핑되어 리스트로 반환
+- 검색 API: `GET /api/abandoned/abandoned-pets/search`
+  - Query Parameter: `type`, `location`, `foundDate(yyyy-MM-dd)`
+  - 로그인 사용자만 접근 가능하도록 설정 (Spring Security 적용)
 
 ---
 
 ### 🧪 테스트 방법
 <!-- 어떻게 테스트했는지, 테스트 시나리오가 있다면 적어주세요 -->
 1. Swagger 또는 Postman으로 로그인한 상태에서 아래 요청 수행
-2. `POST /api/pet/enroll`
-  - Body에 반려동물 정보(`name`, `type`, `age`, `weight`, `gender`, `size`, `adopt`) 포함
-  - 응답: `200 OK - 반려동물 등록 성공`
-3. `GET /api/pet/profile/pets`
-  - 응답: 로그인된 사용자의 반려동물 리스트(JSON 배열 형태)
+2. `POST /api/abandoned/register`
+  - Body에 유기동물 정보(`latitude`, `longitude`, `imageUrl`, `gender`, `description`, `location`, `type`, `foundDate`, `foundTime`) 포함
+  - 응답: `200 OK - 유기동물 제보 성공`
+3. `POST /api/abandoned/admin/reports/{id}/`
+  - 응답: `200 OK - 유기동물 등록 성공`
+4. `GET /api/abandoned/abandoned-pets/search`
+  - 응답: `200 [ {
+    "id": 2,
+    "type": "비숑",
+    "gender": "string",
+    "foundDate": "2025-07-09",
+    "foundTime": "14:30",
+    "description": null,
+    "location": "string"
+    } ]`
 
----
-
-### 📷 스크린샷 (선택)
-<!-- UI 작업을 했다면 캡처 첨부해주세요 -->
-_(예: Swagger UI 요청 화면 등 필요 시 추가)_
-
----
-
-### 🔍 중점적으로 봐줬으면 하는 부분
-<!-- 리뷰어가 특히 신경써서 봐야 할 코드나 로직이 있다면 적어주세요 -->
-- `PetService` 내 DTO → Entity 변환 및 연관관계 설정이 적절한지
-- `PetController`에서 인증된 유저 정보 처리 흐름이 안전하고 자연스러운지
-- DTO를 활용한 응답 구조가 API 응답에 적절하게 구성되었는지
-- Security 설정에서 해당 API 접근이 적절히 보호되고 있는지
-
----
-
-### 📎 관련 이슈
-- Resolved: #반려동물-등록-조회-기능

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ target/
 *.iws
 *.iml
 *.ipr
+.idea/dbnavigator.xml
+.idea/vcs.xml
 
 ### NetBeans ###
 /nbproject/private/

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,36 @@
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
 
+		<!-- Elasticsearch -->
+		<dependency>
+			<groupId>co.elastic.clients</groupId>
+			<artifactId>elasticsearch-java</artifactId>
+			<version>8.13.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-elasticsearch</artifactId>
+		</dependency>
+
+		<!-- HTTP 통신을 위한 Elasticsearch Transport -->
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>elasticsearch-rest-client</artifactId>
+			<version>8.13.4</version>
+		</dependency>
+
+		<!-- JSON 직렬화 매퍼 -->
+		<dependency>
+			<groupId>jakarta.json</groupId>
+			<artifactId>jakarta.json-api</artifactId>
+			<version>2.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/pawnder/controller/AbandonedPetController.java
+++ b/src/main/java/com/pawnder/controller/AbandonedPetController.java
@@ -2,12 +2,16 @@ package com.pawnder.controller;
 
 import com.pawnder.dto.AbandonPetFormDto;
 import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AbandonedPetDocument;
 import com.pawnder.repository.AbandonedPetRepository;
+import com.pawnder.repository.AbandonedPetSearchRepository;
 import com.pawnder.service.AbandonPetService;
+import com.pawnder.service.AbandonedPetSearchService;
 import com.pawnder.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -26,6 +31,7 @@ public class AbandonedPetController {
     private final FileService fileService;
     private final AbandonPetService abandonPetService;
     private final AbandonedPetRepository abandonedPetRepository;
+    private final AbandonedPetSearchService abandonedPetSearchService;
 
     @Operation(summary = "유기동물 제보 (JSON)")
     @PostMapping(value = "/register", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -59,6 +65,19 @@ public class AbandonedPetController {
     public List<AbandonedPet> getAllAbandonedPets() {
         return abandonPetService.getAllAbandonedPets();
     }
+
+
+    //Elasticsearch 적용 검색 필터링
+    @Operation(summary = "유기동물 복합 조건 검색")
+    @GetMapping("/abandoned-pets/search")
+    public List<AbandonedPetDocument> searchAbandonedPets(
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate foundDate) {
+
+        return abandonedPetSearchService.search(type, location, foundDate);
+    }
+
 
     @Operation(summary = "특정 유기동물 1마리에 대한 정보")
     @GetMapping("/abandoned-pets/{id}")

--- a/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
+++ b/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
@@ -29,6 +29,12 @@ public class AbandonPetFormDto {
     // 특이사항 (ex. "다리를 절음", "사람을 잘 따름" 등)
     private String description;
 
+    // 발견된 지역
+    private String location;
+
+    // 품종
+    private String type;
+
     @Schema(type = "string", format = "date", example = "2025-07-09")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate foundDate;

--- a/src/main/java/com/pawnder/entity/AbandonedPet.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPet.java
@@ -24,7 +24,8 @@ public class AbandonedPet {
     private String gender;                // 성별 (M/F)
     private LocalDate foundDate;          // 발견 날짜
     private LocalTime foundTime;          // 발견 시간
-    private String description; // 특이사항
+    private String description;           // 특이사항
+    private String location;              // 발견된 장소
 
     @Enumerated(EnumType.STRING)
     private PetStatus status;// 상태 (ex: 보호중- PROTECTING, 입양완료 - ADOPTED 등)

--- a/src/main/java/com/pawnder/entity/AbandonedPetForm.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPetForm.java
@@ -24,6 +24,8 @@ public class AbandonedPetForm {
     private String imageUrl;
     private LocalDate foundDate;
     private LocalTime foundTime;
+    private String location;
+    private String type;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;


### PR DESCRIPTION
### 📌 PR 개요
<!-- 이 PR이 어떤 기능/수정/버그패치인지 간략하게 설명해주세요 -->
ElasticSearch를 통한 유기동물 복합 조건 검색을 구현하였습니다.

---

### 🔨 작업 내용 요약
<!-- 주요 변경사항을 bullet 형식으로 요약해 주세요 -->
- 기능 추가: 로그인된 유저의 유기동물 복합 조건 검색 API (`GET /api/abandoned/abandoned-pets/search`)
- 🔄 전체 흐름
  1. Controller(`AbandonedPetController`)에서 검색 조건(`type`, `location`, `foundDate`)을 Query Parameter로 전달받음
  2. Service(`AbandonedPetSearchService`)에서 조건에 맞게 Elasticsearch DSL 쿼리를 동적으로 구성
  3. `ElasticsearchClient`를 사용해 검색 요청 수행
  4. 검색된 결과를 `AbandonedPetDocument` 리스트로 매핑하여 반환
- 🔍 검색 조건 및 쿼리 DSL 구성
  - 사용자가 입력한 조건은 모두 **AND 조건**(`bool.must`)으로 적용됨
  - 조건이 없으면 `match_all` 쿼리를 사용하여 전체 데이터를 조회함
  - 각 필드별 검색 방식은 다음과 같음:
    - `type`, `foundDate`: `Keyword` 타입이므로 `term` 쿼리 사용
    - `location`: `Text` 타입이므로 `match` 쿼리 사용
  - 예시 DSL 구조:
    ```json
    {
      "bool": {
        "must": [
          { "term": { "type": "비숑" } },
          { "match": { "location": "인천" } },
          { "term": { "foundDate": "2025-07-09" } }
        ]
      }
    }
    ```
---


### ✅ 상세 구현 내용
<!-- 상세하게 어떤 작업을 했는지 설명해주세요 -->
- Elasticsearch Java API Client를 활용하여 유기동물 복합 조건 검색 기능 구현
- 검색 조건: 품종(`type`), 발견 장소(`location`), 발견 날짜(`foundDate`)를 기반으로 검색 가능
  - `type`, `foundDate` 필드는 `Keyword` 타입 → `term` 쿼리 사용
  - `location` 필드는 `Text` 타입 → `match` 쿼리 사용
- 검색 조건은 선택적으로 입력할 수 있도록 구성 (AND 조건)
  - 조건이 하나도 없을 경우, 전체 데이터를 `match_all` 쿼리로 조회
- 검색 쿼리는 `BoolQuery`를 구성하여 `must` 절에 조건별 `Query` 추가
- 검색 결과는 `AbandonedPetDocument` 클래스로 매핑되어 리스트로 반환
- 검색 API: `GET /api/abandoned/abandoned-pets/search`
  - Query Parameter: `type`, `location`, `foundDate(yyyy-MM-dd)`
  - 로그인 사용자만 접근 가능하도록 설정 (Spring Security 적용)

---

### 🧪 테스트 방법
<!-- 어떻게 테스트했는지, 테스트 시나리오가 있다면 적어주세요 -->
1. Swagger 또는 Postman으로 로그인한 상태에서 아래 요청 수행
2. `POST /api/abandoned/register`
  - Body에 유기동물 정보(`latitude`, `longitude`, `imageUrl`, `gender`, `description`, `location`, `type`, `foundDate`, `foundTime`) 포함
  - 응답: `200 OK - 유기동물 제보 성공`
3. `POST /api/abandoned/admin/reports/{id}/`
  - 응답: `200 OK - 유기동물 등록 성공`
4. `GET /api/abandoned/abandoned-pets/search`
  - 응답: `200 [ {
    "id": 2,
    "type": "비숑",
    "gender": "string",
    "foundDate": "2025-07-09",
    "foundTime": "14:30",
    "description": null,
    "location": "string"
    } ]`

