### PR TITLE
fix : 유기동물 복합 조건 필터링 검색

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,10 +127,18 @@
 			<artifactId>jakarta.json-api</artifactId>
 			<version>2.1.1</version>
 		</dependency>
+		<!-- Jackson Core 모듈들 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.15.3</version>
+		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.15.3</version>
 		</dependency>
+
 
 	</dependencies>
 

--- a/src/main/java/com/pawnder/config/ElasticsearchConfig.java
+++ b/src/main/java/com/pawnder/config/ElasticsearchConfig.java
@@ -1,0 +1,35 @@
+package com.pawnder.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Base64;
+
+public class ElasticsearchConfig {
+    @Value("${spring.elasticsearch.uris}")
+    private String elasticsearchUrl;
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        RestClient restClient = RestClient.builder(
+                HttpHost.create(elasticsearchUrl)
+                /*.setDefaultHeaders(new Header[]{
+                        new BasicHeader("Authorization", "Basic " + Base64.getEncoder()
+                                .encodeToString("elastic:비밀번호".getBytes()))
+                })*/
+        ).build();
+
+        ElasticsearchTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper());
+
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/src/main/java/com/pawnder/config/JacksonConfig.java
+++ b/src/main/java/com/pawnder/config/JacksonConfig.java
@@ -1,0 +1,26 @@
+package com.pawnder.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JacksonConfig {
+
+    private final ObjectMapper objectMapper;
+
+    public JacksonConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void setUp() {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.findAndRegisterModules(); // 이거 하나면 대부분 자동 등록됨
+        // ISO 날짜로 출력하고 싶을 때
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}
+

--- a/src/main/java/com/pawnder/config/SecurityConfig.java
+++ b/src/main/java/com/pawnder/config/SecurityConfig.java
@@ -9,8 +9,12 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -76,7 +80,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of("http://localhost:3000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true); // ✅ 세션 쿠키를 프론트로 전달
+        config.setAllowCredentials(true); // 세션 쿠키를 프론트로 전달
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/pawnder/controller/AbandonedPetController.java
+++ b/src/main/java/com/pawnder/controller/AbandonedPetController.java
@@ -1,8 +1,12 @@
 package com.pawnder.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawnder.config.SessionUtil;
 import com.pawnder.dto.AbandonPetFormDto;
+import com.pawnder.dto.PetProfileDto;
 import com.pawnder.entity.AbandonedPet;
 import com.pawnder.entity.AbandonedPetDocument;
+import com.pawnder.entity.User;
 import com.pawnder.repository.AbandonedPetRepository;
 import com.pawnder.repository.AbandonedPetSearchRepository;
 import com.pawnder.service.AbandonPetService;
@@ -10,80 +14,115 @@ import com.pawnder.service.AbandonedPetSearchService;
 import com.pawnder.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/abandoned")
 @Tag(name = "AbandonPet", description = "유기동물 관련 API")
 public class AbandonedPetController {
-    private final FileService fileService;
     private final AbandonPetService abandonPetService;
     private final AbandonedPetRepository abandonedPetRepository;
     private final AbandonedPetSearchService abandonedPetSearchService;
 
-    @Operation(summary = "유기동물 제보 (JSON)")
-    @PostMapping(value = "/register", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> registerAdoptPet(@AuthenticationPrincipal UserDetails userDetails,
-                                              @RequestBody AbandonPetFormDto dto) {
-        // imageUrl 필드는 나중에 넣거나, 임시 URL을 dto에 포함해도 됨
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 후 이용해주세요.");
-        }//디버깅
+    @Operation(summary = "유기동물 제보")
+    @PostMapping(value = "/register")
+    public ResponseEntity<Map<String, Object>> registerAbandonedPet(
+            @RequestPart("abandoned-pet") String abandonedPetJson,
+            @RequestPart("imageurl")MultipartFile imageurl,
+            HttpServletRequest request) {
 
-        String userId = userDetails.getUsername(); // 또는 userDetails.getUserId() 등
+        Map<String, Object> response = new HashMap<>();
+        try {
+            // 현재 로그인한 사용자 정보 가져오기
+            String userId = getCurrentUserId(request);
+            if (userId == null) {
+                response.put("success", false);
+                response.put("message", "로그인이 필요합니다.");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+            }
 
-        abandonPetService.save(dto, userId);
-        return ResponseEntity.ok("유기 동물 등록 성공 (JSON)");
+            // JSON 파싱
+            ObjectMapper mapper = new ObjectMapper();
+            AbandonPetFormDto abandonPetFormDto = mapper.readValue(abandonedPetJson, AbandonPetFormDto.class);
+
+            // 유기견 제보 등록
+            abandonPetService.save(abandonPetFormDto, userId, imageurl);
+
+            response.put("success", true);
+            response.put("message", "유기견 등록이 완료되었습니다.");
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("유기견 등록 중 오류 발생", e);
+            response.put("success", false);
+            response.put("message", "등록 중 오류가 발생했습니다: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
     }
-
-
-    //유기 등록 (관리자)
-    @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "유기동물 제보 등록")
-    @PostMapping("/admin/reports/{id}/register")
-    public String registerAnimal(@PathVariable Long id) {
-        abandonPetService.registerAsAbandonedPet(id);
-        return "redirect:/admin/reports";
-    }
-
-
-    //유기 조회 (유저/관리자)
-    @Operation(summary = "유기동물 제보리스트 (JSON)")
-    @GetMapping("/abandoned-pets")
-    public List<AbandonedPet> getAllAbandonedPets() {
-        return abandonPetService.getAllAbandonedPets();
-    }
-
 
     //Elasticsearch 적용 검색 필터링
     @Operation(summary = "유기동물 복합 조건 검색")
     @GetMapping("/abandoned-pets/search")
     public List<AbandonedPetDocument> searchAbandonedPets(
-            @RequestParam(required = false) String type,
-            @RequestParam(required = false) String location,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate foundDate) {
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate foundDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime foundTime,
+            @RequestParam(required = false) String location) {
 
-        return abandonedPetSearchService.search(type, location, foundDate);
+        return abandonedPetSearchService.search(foundDate, foundTime, location);
     }
 
 
-    @Operation(summary = "특정 유기동물 1마리에 대한 정보")
-    @GetMapping("/abandoned-pets/{id}")
-    public ResponseEntity<AbandonedPet> getAbandonedPetById(@PathVariable Long id) {
-        AbandonedPet pet = abandonedPetRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유기동물이 없습니다."));
-        return ResponseEntity.ok(pet);
+    /**
+     * 현재 로그인한 사용자의 userId를 가져오는 헬퍼 메서드
+     */
+    private String getCurrentUserId(HttpServletRequest request) {
+        try {
+            // 1. 세션에서 먼저 확인
+            HttpSession session = request.getSession(false);
+            if (session != null) {
+                User sessionUser = SessionUtil.getLoginUser(session);
+                if (sessionUser != null) {
+                    return sessionUser.getUserId();
+                }
+
+                // 또는 String으로 저장된 userId 확인
+                String userId = SessionUtil.getLoginUserId(session);
+                if (userId != null) {
+                    return userId;
+                }
+            }
+
+            // 2. Spring Security에서 확인
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getName())) {
+                return auth.getName();
+            }
+
+            return null;
+        } catch (Exception e) {
+            log.error("사용자 ID 조회 중 오류 발생", e);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/pawnder/controller/AdminController.java
+++ b/src/main/java/com/pawnder/controller/AdminController.java
@@ -1,0 +1,83 @@
+package com.pawnder.controller;
+
+import com.pawnder.config.SessionUtil;
+import com.pawnder.constant.Role;
+import com.pawnder.dto.AbandonPetFormDto;
+import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AbandonedPetForm;
+import com.pawnder.entity.User;
+import com.pawnder.repository.AbandonedPetFormRepository;
+import com.pawnder.service.AbandonPetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.jpa.domain.AbstractPersistable_.id;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+@Tag(name = "Admin", description = "관리자 관련 API")
+public class AdminController {
+
+    private final AbandonPetService abandonPetService;
+    private final AbandonedPetFormRepository abandonedPetFormRepository;
+
+    @Operation(summary = "유기동물 제보 등록 (관리자만)")
+    @PostMapping("/reports/{id}/register")
+    public ResponseEntity<?> registerAnimal(HttpSession session, @PathVariable Long id) {
+        User user = SessionUtil.getLoginUser(session);
+
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+
+        if (user.getRole() != Role.ADMIN) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("관리자만 접근 가능합니다.");
+        }
+
+        try {
+            abandonPetService.registerAsAbandonedPet(id);
+            return ResponseEntity.ok("제보가 유기동물로 등록되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("등록 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    //유기 조회 (유저/관리자)
+    @Operation(summary = "유기동물 제보리스트 (JSON) 조회")
+    @GetMapping("/abandoned-pets")
+    public ResponseEntity<List<AbandonPetFormDto>> getAll() {
+        List<AbandonedPetForm> forms = abandonedPetFormRepository.findAll();
+        List<AbandonPetFormDto> dtoList = forms.stream()
+                .map(AbandonPetFormDto::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtoList);
+    }
+
+    @GetMapping("/abandoned-pets/{id}")
+    public ResponseEntity<AbandonPetFormDto> getAbandonedPetById(@PathVariable Long id) {
+        Optional<AbandonedPetForm> optionalForm = abandonedPetFormRepository.findById(id);
+
+        if (optionalForm.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        AbandonPetFormDto dto = new AbandonPetFormDto(optionalForm.get());
+        return ResponseEntity.ok(dto);
+    }
+
+
+}
+

--- a/src/main/java/com/pawnder/controller/CommunityController.java
+++ b/src/main/java/com/pawnder/controller/CommunityController.java
@@ -1,0 +1,51 @@
+package com.pawnder.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/community")
+@Tag(name = "Community", description = "커뮤니티 관련 API")
+public class CommunityController {
+
+    @Operation(summary = "입양 후기 작성")
+    @PostMapping("/adopt/review/register")
+    public ResponseEntity<?> registerAdoptedReview(@AuthenticationPrincipal UserDetails userDetails) {
+        String userId = userDetails.getUsername();
+        return ResponseEntity.ok("입양 후기 등록 완료");
+    }
+
+    @Operation(summary = "나의 반려견 자랑하기")
+    @PostMapping("/mypet/register")
+    public ResponseEntity<?> registerMyPetCommunity(@AuthenticationPrincipal UserDetails userDetails) {
+        String userId = userDetails.getUsername();
+        return ResponseEntity.ok("반려견 자랑 등록 완료");
+    }
+
+    @Operation(summary = "커뮤니티 글 조회")
+    @GetMapping("/list")
+    public ResponseEntity<?> getPostList() {
+        return ResponseEntity.ok("리스트 조회 완료");
+    }
+
+    @Operation(summary = "좋아요 달기")
+    @PostMapping("/like")
+    public ResponseEntity<?> likePost() {
+        return ResponseEntity.ok("좋아요 완료");
+    }
+
+    @Operation(summary = "댓글 달기")
+    @PostMapping("/comment")
+    public ResponseEntity<?> commentPost() {
+        return ResponseEntity.ok("댓글 등록 완료");
+    }
+}

--- a/src/main/java/com/pawnder/controller/UserController.java
+++ b/src/main/java/com/pawnder/controller/UserController.java
@@ -92,7 +92,7 @@ public class UserController {
             SecurityContext context = SecurityContextHolder.getContext();
             context.setAuthentication(authToken);
 
-            // ✅ 세션에 SecurityContext 저장
+            // 세션에 SecurityContext 저장
             session.setAttribute("SPRING_SECURITY_CONTEXT", context);
 
             return ResponseEntity.ok("로그인 성공!");

--- a/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
+++ b/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
@@ -1,5 +1,6 @@
 package com.pawnder.dto;
 
+import com.pawnder.entity.AbandonedPetForm;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,33 +15,42 @@ import java.time.LocalTime;
 @Setter
 @Schema(description = "유기동물 제보 DTO")
 public class AbandonPetFormDto {
-    // 발견한 장소 위도
+
+    private Long id;
+
     private double latitude;
-
-    // 발견한 장소 경도
     private double longitude;
-
-    // 동물 이미지 (파일명 or URL or Multipart 처리용 필드)
-    private String imageUrl; // 또는 MultipartFile image로 처리할 수도 있음
-
-    // 성별 (예: "수컷", "암컷", "중성화 여부 포함 등")
+    private String imageUrl;
     private String gender;
-
-    // 특이사항 (ex. "다리를 절음", "사람을 잘 따름" 등)
     private String description;
-
-    // 발견된 지역
     private String location;
-
-    // 품종
     private String type;
 
     @Schema(type = "string", format = "date", example = "2025-07-09")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-    private LocalDate foundDate;
+    private String foundDate;
 
     @Schema(type = "string", format = "time", example = "14:30")
     @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
-    private LocalTime foundTime;
+    private String foundTime;
 
+    // 등록한 사용자 정보 (ID 또는 닉네임)
+    private String userId;
+
+    // 생성자 추가
+    public AbandonPetFormDto(AbandonedPetForm form) {
+        this.id = form.getId();
+        this.latitude = form.getLatitude();
+        this.longitude = form.getLongitude();
+        this.imageUrl = form.getImageUrl();
+        this.gender = form.getGender();
+        this.description = form.getDescription();
+        this.location = form.getLocation();
+        this.type = form.getType();
+        this.foundDate = form.getFoundDate().toString();
+        this.foundTime = form.getFoundTime().toString();
+
+        // 유저 ID 추가
+        this.userId = form.getUser().getUserId(); // 또는 .getEmail() 혹은 .getNickname()
+    }
 }

--- a/src/main/java/com/pawnder/entity/AbandonedPet.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPet.java
@@ -22,8 +22,8 @@ public class AbandonedPet {
     // 제보 기반 정보
     private String type;                  // 품종
     private String gender;                // 성별 (M/F)
-    private LocalDate foundDate;          // 발견 날짜
-    private LocalTime foundTime;          // 발견 시간
+    private String foundDate;          // 발견 날짜
+    private String foundTime;          // 발견 시간
     private String description;           // 특이사항
     private String location;              // 발견된 장소
 

--- a/src/main/java/com/pawnder/entity/AbandonedPetDocument.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPetDocument.java
@@ -1,0 +1,41 @@
+package com.pawnder.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Document(indexName = "abandoned-pets")
+@Getter
+@Setter
+public class AbandonedPetDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Keyword)
+    private String type;            // 품종
+
+    @Field(type = FieldType.Keyword)
+    private String gender;          // 성별
+
+    @Field(type = FieldType.Text)
+    private String foundDate;
+
+    @Field(type = FieldType.Text)
+    private String foundTime; // "13:25:00" 형태로 저장
+
+    @Field(type = FieldType.Text)
+    private String description;
+
+    @Field(type = FieldType.Keyword)
+    private String location;
+
+
+}

--- a/src/main/java/com/pawnder/entity/AbandonedPetForm.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPetForm.java
@@ -21,13 +21,14 @@ public class AbandonedPetForm {
     private String description;
     private double latitude;
     private double longitude;
-    private String imageUrl;
-    private LocalDate foundDate;
-    private LocalTime foundTime;
+    private String imageUrl = "default-profile.png";
+    private String foundDate;
+    private String foundTime;
     private String location;
     private String type;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 }
 

--- a/src/main/java/com/pawnder/repository/AbandonedPetFormRepository.java
+++ b/src/main/java/com/pawnder/repository/AbandonedPetFormRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface AdoptPetFormRepository extends JpaRepository<AbandonedPetForm, Long> {
+public interface AbandonedPetFormRepository extends JpaRepository<AbandonedPetForm, Long> {
     List<AbandonedPetForm> findByUserUserId(String userId);
 }

--- a/src/main/java/com/pawnder/repository/AbandonedPetSearchRepository.java
+++ b/src/main/java/com/pawnder/repository/AbandonedPetSearchRepository.java
@@ -1,0 +1,19 @@
+package com.pawnder.repository;
+
+import com.pawnder.entity.AbandonedPetDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AbandonedPetSearchRepository extends ElasticsearchRepository<AbandonedPetDocument, Long> {
+    // type으로 검색
+    List<AbandonedPetDocument> findByTypeContaining(String type);
+
+    //location으로 검색
+    List<AbandonedPetDocument> findByLocationContaining(String location);
+
+    //foundDate으로 검색
+    List<AbandonedPetDocument> findByFoundDate(LocalDate foundDate);
+    
+}

--- a/src/main/java/com/pawnder/service/AbandonedPetElasticService.java
+++ b/src/main/java/com/pawnder/service/AbandonedPetElasticService.java
@@ -1,0 +1,35 @@
+package com.pawnder.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AbandonedPetDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AbandonedPetElasticService {
+    private final ElasticsearchClient elasticsearchClient;
+
+    public void saveToElasticsearch(AbandonedPet pet) {
+        try {
+            AbandonedPetDocument doc = new AbandonedPetDocument();
+            doc.setId(pet.getId());
+            doc.setLocation(pet.getLocation()); // 직접 필드에 맞게 매핑
+            doc.setGender(pet.getGender());
+            doc.setType(pet.getType());
+            doc.setFoundDate(pet.getFoundDate().toString());
+            doc.setFoundTime(pet.getFoundTime().toString());
+
+            elasticsearchClient.index(i -> i
+                    .index("abandoned-pets")
+                    .id(String.valueOf(doc.getId()))
+                    .document(doc)
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/pawnder/service/AbandonedPetSearchService.java
+++ b/src/main/java/com/pawnder/service/AbandonedPetSearchService.java
@@ -1,0 +1,78 @@
+package com.pawnder.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.pawnder.entity.AbandonedPetDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AbandonedPetSearchService {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    public List<AbandonedPetDocument> search(LocalDate foundDate, LocalTime foundTime, String location) {
+        try {
+            // 쿼리 리스트 생성
+            List<Query> mustQueries = new ArrayList<>();
+
+            if (foundDate != null) {
+                mustQueries.add(Query.of(q -> q
+                        .term(t -> t
+                                .field("foundDate")
+                                .value(foundDate.toString())
+                        )
+                ));
+            }
+
+            if (foundTime != null) {
+                mustQueries.add(Query.of(q -> q
+                        .term(m -> m
+                                .field("foundTime")
+                                .value(foundTime.toString())
+                        )
+                ));
+            }
+
+            if (location != null && !location.isEmpty()) {
+                mustQueries.add(Query.of(q -> q
+                        .term(t -> t
+                                .field("location")
+                                .value(location)
+                        )
+                ));
+            }
+
+            // bool 쿼리 조립
+            BoolQuery boolQuery = BoolQuery.of(b -> b.must(mustQueries));
+
+            // 검색 요청
+            SearchResponse<AbandonedPetDocument> response = elasticsearchClient.search(s -> s
+                            .index("abandoned-pets")
+                            .query(q -> q
+                                    .bool(boolQuery)
+                            ),
+                    AbandonedPetDocument.class
+            );
+
+            // 결과 반환
+            return response.hits().hits().stream()
+                    .map(hit -> hit.source())
+                    .toList();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return List.of(); // 예외 발생 시 빈 리스트 반환
+        }
+    }
+}
+


### PR DESCRIPTION
### 📌 PR 개요
<!-- 이 PR이 어떤 기능/수정/버그패치인지 간략하게 설명해주세요 -->
ElasticSearch를 통한 유기동물 복합 조건 검색 기준을 수정하였습니다.

---

### 🔨 작업 내용 요약
<!-- 주요 변경사항을 bullet 형식으로 요약해 주세요 -->
- 기능 추가: 로그인된 유저의 유기동물 복합 조건 검색 API (`GET /api/abandoned/abandoned-pets/search`)
- 🔄 전체 흐름
  1. Controller(`AbandonedPetController`)에서 검색 조건(`foundDate`, `foundTime`, `location`)을 Query Parameter로 전달받음
  2. Service(`AbandonedPetSearchService`)에서 조건에 맞게 Elasticsearch DSL 쿼리를 동적으로 구성
  3. `ElasticsearchClient`를 사용해 검색 요청 수행
  4. 검색된 결과를 `AbandonedPetDocument` 리스트로 매핑하여 반환
- 🔍 검색 조건 및 쿼리 DSL 구성
  - 사용자가 입력한 조건은 모두 **AND 조건**(`bool.must`)으로 적용됨
  - 조건이 없으면 `match_all` 쿼리를 사용하여 전체 데이터를 조회함
  - 각 필드별 검색 방식은 다음과 같음:
    - `foundDate`, `foundTime`, `location: `keyword` 타입이므로 `term` 쿼리 사용
    - `Text` 타입은 추후 `match` 쿼리 사용
  - 예시 DSL 구조:
    ```json
    {
      "bool": {
        "must": [
          { "term": { "foundDate": "2025-07-09" } },
          { "term": { "foundTime": "HH:mm" } },
          { "term": { "location": "인천" } }
        ]
      }
    }
    ```
---


### ✅ 상세 구현 내용
<!-- 상세하게 어떤 작업을 했는지 설명해주세요 -->
- Elasticsearch Java API Client를 활용하여 유기동물 복합 조건 검색 기능 구현
- 사용자가 유기견을 검색할 때 이 API를 사용
- 검색 조건: 발견 날짜(`foundDate`), 발견 시각 (`foundTime`) 발견 장소(`location`)를 기반으로 검색 가능
- 검색 조건은 선택적으로 입력할 수 있도록 구성 (AND 조건)
  - 조건이 하나도 없을 경우, 전체 데이터를 `match_all` 쿼리로 조회
- 검색 쿼리는 `BoolQuery`를 구성하여 `must` 절에 조건별 `Query` 추가
- 검색 결과는 `AbandonedPetDocument` 클래스로 매핑되어 리스트로 반환
- 검색 API: `GET /api/abandoned/abandoned-pets/search`
  - Query Parameter: `foundDate(yyyy-MM-dd)`, `foundTime(HH:mm)`, `location`
  - 로그인 사용자만 접근 가능하도록 설정 (Spring Security 적용)

---

### 🧪 테스트 방법
<!-- 어떻게 테스트했는지, 테스트 시나리오가 있다면 적어주세요 -->
1. Swagger 또는 Postman으로 로그인한 상태에서 아래 요청 수행
2. `POST /api/abandoned/register`
  - Body에 유기동물 정보(`latitude`, `longitude`, `imageUrl`, `gender`, `description`, `location`, `type`, `foundDate`, `foundTime`) 포함
  - 응답: `200 OK - 유기동물 제보 성공`
3. `POST /api/abandoned/admin/reports/{id}/`
  - 응답: `200 OK - 유기동물 등록 성공`
4. `GET /api/abandoned/abandoned-pets/search`

