### PR TITLE
feat: 입양 신청/승인 기능 구현

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,18 @@
 ### 📌 PR 개요
-<!-- 이 PR이 어떤 기능/수정/버그패치인지 간략하게 설명해주세요 -->
-커뮤니티의 전반적인 기능을 구현했습니다.
+관리자가 입양 신청을 승인할 수 있는 기능을 구현했습니다.
 
 ---
 
 ### 🔨 작업 내용 요약
-<!-- 주요 변경사항을 bullet 형식으로 요약해 주세요 -->
-- 기능 추가: 로그인된 사용자의 session으로 게시글을 작성할 수 있도록 구현 (`/api/community/createPost`)
-- 기능 추가: 로그인된 사용자의 session으로 게시글을 수정할 수 있도록 구현 (`/api/community/description/{postId}/edit`)
-- 기능 추가: 커뮤니티 전체 글 조회 기능 구현 (`/api/community/posts`)
-- 기능 추가: 커뮤니티 상세 글 조회 기능 구현 (`/api/community/description/{postId}`)
-- 기능 추가: 커뮤니티 상세 글 삭제 기능 구현 (`/api/community/description/{postId}/delete`)
+- 기능 추가: 입양 신청 승인 기능 구현 (`approveAdoption`)
+- 수정: AdoptPet ID 기반으로 AbandonedPet, AbandonedPetForm 상태 변경
+- 프론트 연동: 승인 버튼 클릭 시 adoptPetId 기반으로 승인 요청 전송
+
 ---
 
-
 ### ✅ 상세 구현 내용
-<!-- 상세하게 어떤 작업을 했는지 설명해주세요 -->
-
+- `approveAdoption(Long adoptPetId)` 메서드에서 AdoptPet ID를 기준으로 입양 신청을 조회
+- 해당 입양 신청과 연관된 AbandonedPet 및 AbandonedPetForm 엔티티 상태를 `ADOPT`로 변경
+- AdoptPet 상태는 `APPROVED`로 변경되며 승인 시각도 함께 기록
+- 기존에 잘못된 `petId` 기반 로직 제거하고 올바른 관계 기반 처리 방식 적용
+- React 프론트엔드에서 "승인" 버튼 클릭 시 `adoptPetId`가 서버로 전달되도록 연동 완료

--- a/src/main/java/com/pawnder/config/SecurityConfig.java
+++ b/src/main/java/com/pawnder/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                                 "/api/users/logout",
                                 "/api/users/check-session",
                                 "/api/community/**",
+                                "/api/adopt/**",
 
                                 "/swagger-ui/**",         // Swagger UI 리소스
                                 "/v3/api-docs/**"         // OpenAPI 문서 경로

--- a/src/main/java/com/pawnder/constant/AdoptStatus.java
+++ b/src/main/java/com/pawnder/constant/AdoptStatus.java
@@ -1,0 +1,7 @@
+package com.pawnder.constant;
+
+public enum AdoptStatus {
+    REQUESTED, // 입양 신청됨
+    APPROVED,  // 승인됨
+    REJECTED   // 거절됨
+}

--- a/src/main/java/com/pawnder/constant/PetStatus.java
+++ b/src/main/java/com/pawnder/constant/PetStatus.java
@@ -4,6 +4,6 @@ package com.pawnder.constant;
 public enum PetStatus {
     PROTECTING, //유기견 승인
     ADOPT, //입양승인
-    WAITING_ADOPTION, //입양대기 (관리자 제보리스트에 입양대기로 표시)
+    WAITING, //입양대기 (관리자 제보리스트에 입양대기로 표시)
     LOST //유기견 대기(목록에서 제외)
 }

--- a/src/main/java/com/pawnder/controller/AbandonedPetController.java
+++ b/src/main/java/com/pawnder/controller/AbandonedPetController.java
@@ -2,11 +2,14 @@ package com.pawnder.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawnder.config.SessionUtil;
+import com.pawnder.constant.PetStatus;
 import com.pawnder.dto.AbandonPetFormDto;
 import com.pawnder.dto.PetProfileDto;
 import com.pawnder.entity.AbandonedPet;
 import com.pawnder.entity.AbandonedPetDocument;
+import com.pawnder.entity.AbandonedPetForm;
 import com.pawnder.entity.User;
+import com.pawnder.repository.AbandonedPetFormRepository;
 import com.pawnder.repository.AbandonedPetRepository;
 import com.pawnder.repository.AbandonedPetSearchRepository;
 import com.pawnder.service.AbandonPetService;
@@ -35,6 +38,8 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -44,6 +49,7 @@ public class AbandonedPetController {
     private final AbandonPetService abandonPetService;
     private final AbandonedPetRepository abandonedPetRepository;
     private final AbandonedPetSearchService abandonedPetSearchService;
+    private final AbandonedPetFormRepository abandonedPetFormRepository;
 
     @Operation(summary = "유기동물 제보")
     @PostMapping(value = "/register")
@@ -90,6 +96,18 @@ public class AbandonedPetController {
             @RequestParam(required = false) String location) {
 
         return abandonedPetSearchService.search(foundDate, foundTime, location);
+    }
+
+    //유기견 조회 (유저/관리자)
+    @Operation(summary = "유기동물 승인 제보리스트 (JSON) 조회")
+    @GetMapping("/abandoned-pets")
+    public ResponseEntity<List<AbandonPetFormDto>> getAll() {
+        List<PetStatus> statuses = List.of(PetStatus.PROTECTING, PetStatus.WAITING);
+        List<AbandonedPetForm> pets = abandonedPetFormRepository.findByStatusIn(statuses);
+        List<AbandonPetFormDto> dtoList = pets.stream()
+                .map(AbandonPetFormDto::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtoList);
     }
 
 

--- a/src/main/java/com/pawnder/controller/AdminController.java
+++ b/src/main/java/com/pawnder/controller/AdminController.java
@@ -3,14 +3,19 @@ package com.pawnder.controller;
 import com.pawnder.config.SessionUtil;
 import com.pawnder.constant.Role;
 import com.pawnder.dto.AbandonPetFormDto;
+import com.pawnder.dto.AdoptPetDto;
 import com.pawnder.entity.AbandonedPet;
 import com.pawnder.entity.AbandonedPetForm;
+import com.pawnder.entity.AdoptPet;
 import com.pawnder.entity.User;
 import com.pawnder.repository.AbandonedPetFormRepository;
+import com.pawnder.repository.AdoptPetRepository;
 import com.pawnder.service.AbandonPetService;
+import com.pawnder.service.AdoptPetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -33,6 +38,8 @@ public class AdminController {
 
     private final AbandonPetService abandonPetService;
     private final AbandonedPetFormRepository abandonedPetFormRepository;
+    private final AdoptPetService adoptPetService;
+    private final AdoptPetRepository adoptPetRepository;
 
     @Operation(summary = "유기동물 제보 등록 (관리자만)")
     @PostMapping("/reports/{id}/register")
@@ -79,6 +86,26 @@ public class AdminController {
         return ResponseEntity.ok(dto);
     }
 
+    //관리자 -> 입양 신청 조회
+    @Operation(summary = "입양 신청 전체 조회 (관리자용)")
+    @GetMapping("/adopt-applications")
+    public ResponseEntity<List<AdoptPetDto>> getAllApplications() {
+        List<AdoptPet> adoptPets = adoptPetRepository.findAll();
+
+        List<AdoptPetDto> result = adoptPets.stream()
+                .map(AdoptPetDto::new)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(result);
+    }
+
+    // 관리자 -> 입양 승인시
+    @Operation(summary = "유기견 입양 승인")
+    @PostMapping("/adopt/approve/{id}")
+    public ResponseEntity<?> approveAdoption(@PathVariable Long id) {
+        adoptPetService.approveAdoption(id);
+        return ResponseEntity.ok("승인됨");
+    }
 
 }
 

--- a/src/main/java/com/pawnder/controller/AdoptPetController.java
+++ b/src/main/java/com/pawnder/controller/AdoptPetController.java
@@ -1,16 +1,20 @@
-/*
 package com.pawnder.controller;
 
+import com.pawnder.config.SessionUtil;
+import com.pawnder.repository.AbandonedPetRepository;
+import com.pawnder.service.AdoptPetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-*/
-/* 입양 또는 임시보호 관련 Controller *//*
+ //입양 관련 Controller
 
 @Slf4j
 @RestController
@@ -18,11 +22,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/adopt")
 @Tag(name = "Adopt", description = "입양 관련 API")
 public class AdoptPetController {
+    private final AdoptPetService adoptPetService;
+
+    //유
+
     //기능
-    //1. 유저가 임시보호 요청
-    @Operation(summary = "임시보호 요청")
-    @PostMapping("/")
-    public
-    //2. 유저가 입양 요청
+    //1. 유저 -> 입양 신청시
+    @Operation(summary = "입양 신청")
+    @PostMapping("/apply/{petId}")
+    public ResponseEntity<?> applyAdoption(@PathVariable Long petId, HttpSession session) {
+        String userId = SessionUtil.getLoginUserId(session);
+        //받은 petId를 가지고 서비스에서 AbandonedPetRepository에서 id찾아서
+        //Status를 WAITING_ADOPT로 set
+        adoptPetService.applyAdoption(petId, userId); //status = WAITING
+        return ResponseEntity.ok("신청 완료");
+    }
+
+
 }
-*/

--- a/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
+++ b/src/main/java/com/pawnder/dto/AbandonPetFormDto.java
@@ -1,6 +1,7 @@
 package com.pawnder.dto;
 
 import com.pawnder.constant.PetStatus;
+import com.pawnder.entity.AbandonedPet;
 import com.pawnder.entity.AbandonedPetForm;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -59,4 +60,5 @@ public class AbandonPetFormDto {
         // 유저 ID 추가
         this.userId = form.getUser().getUserId(); // 또는 .getEmail() 혹은 .getNickname()
     }
+
 }

--- a/src/main/java/com/pawnder/dto/AdoptPetDto.java
+++ b/src/main/java/com/pawnder/dto/AdoptPetDto.java
@@ -1,0 +1,31 @@
+package com.pawnder.dto;
+
+import com.pawnder.constant.AdoptStatus;
+import com.pawnder.entity.AdoptPet;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class AdoptPetDto {
+    private Long id;
+    private String userName;
+    private String petImageUrl;
+    private LocalDateTime appliedAt;
+    private AdoptStatus adoptStatus;
+    private String location;
+    private String type;
+
+    public AdoptPetDto(AdoptPet adoptPet) {
+        this.id = adoptPet.getId();
+        this.userName = adoptPet.getUser().getUserId();
+        this.petImageUrl = adoptPet.getAbandonedPet().getImageUrl();
+        this.location = adoptPet.getAbandonedPet().getLocation();
+        this.type = adoptPet.getAbandonedPet().getType();
+        this.appliedAt = adoptPet.getAppliedAt();
+        this.adoptStatus = adoptPet.getAdoptStatus();
+    }
+}
+

--- a/src/main/java/com/pawnder/entity/AbandonedPet.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPet.java
@@ -28,6 +28,7 @@ public class AbandonedPet {
     private String location;              // 발견된 장소
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     private PetStatus status;// 상태 (ex: 보호중- PROTECTING, 입양완료 - ADOPTED 등)
 
     // 이미지 경로

--- a/src/main/java/com/pawnder/entity/AbandonedPetForm.java
+++ b/src/main/java/com/pawnder/entity/AbandonedPetForm.java
@@ -29,6 +29,7 @@ public class AbandonedPetForm {
     private String type;
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     private PetStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/pawnder/entity/AdoptPet.java
+++ b/src/main/java/com/pawnder/entity/AdoptPet.java
@@ -1,0 +1,31 @@
+package com.pawnder.entity;
+
+import com.pawnder.constant.AdoptStatus;
+import com.pawnder.constant.PetStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class AdoptPet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne
+    private AbandonedPet abandonedPet;
+
+    @Enumerated(EnumType.STRING)
+    private AdoptStatus adoptStatus;
+
+
+    private LocalDateTime appliedAt;  // 신청 시간
+    private LocalDateTime approvedAt; // 승인 시간
+}

--- a/src/main/java/com/pawnder/entity/User.java
+++ b/src/main/java/com/pawnder/entity/User.java
@@ -34,4 +34,7 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @JsonManagedReference
     private List<Pet> pets = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<AdoptPet> adoptPetList;
 }

--- a/src/main/java/com/pawnder/repository/AbandonedPetFormRepository.java
+++ b/src/main/java/com/pawnder/repository/AbandonedPetFormRepository.java
@@ -1,5 +1,6 @@
 package com.pawnder.repository;
 
+import com.pawnder.constant.PetStatus;
 import com.pawnder.entity.AbandonedPetForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,7 @@ import java.util.List;
 
 public interface AbandonedPetFormRepository extends JpaRepository<AbandonedPetForm, Long> {
     List<AbandonedPetForm> findByUserUserId(String userId);
+
+    List<AbandonedPetForm> findByStatus(PetStatus status);
+    List<AbandonedPetForm> findByStatusIn(List<PetStatus> statuses);
 }

--- a/src/main/java/com/pawnder/repository/AbandonedPetRepository.java
+++ b/src/main/java/com/pawnder/repository/AbandonedPetRepository.java
@@ -1,7 +1,17 @@
 package com.pawnder.repository;
 
+import com.pawnder.constant.PetStatus;
 import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AbandonedPetForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface AbandonedPetRepository extends JpaRepository<AbandonedPet, Long> {
+    List<AbandonedPet> findByStatus(PetStatus status);
+
+
+    Optional<AbandonedPet> findByAbandonedPetForm_Id(Long abandonedPetFormId);
+
 }

--- a/src/main/java/com/pawnder/repository/AdoptPetRepository.java
+++ b/src/main/java/com/pawnder/repository/AdoptPetRepository.java
@@ -1,0 +1,19 @@
+package com.pawnder.repository;
+
+import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AdoptPet;
+import com.pawnder.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AdoptPetRepository extends JpaRepository<AdoptPet, Long> {
+    Optional<AdoptPet> findByAbandonedPet(AbandonedPet abandonedPet);
+
+    // 또는 여러 유저가 신청할 수 있는 구조라면
+    List<AdoptPet> findAllByAbandonedPet(AbandonedPet abandonedPet);
+
+    // 유저가 특정 유기견에 신청했는지 확인
+    Optional<AdoptPet> findByUserAndAbandonedPet(User user, AbandonedPet abandonedPet);
+}

--- a/src/main/java/com/pawnder/service/AdoptPetService.java
+++ b/src/main/java/com/pawnder/service/AdoptPetService.java
@@ -2,11 +2,74 @@ package com.pawnder.service;
 
 /* 입양 관련 서비스 로직 */
 
+import com.pawnder.constant.AdoptStatus;
+import com.pawnder.constant.PetStatus;
+import com.pawnder.entity.AbandonedPet;
+import com.pawnder.entity.AbandonedPetForm;
+import com.pawnder.entity.AdoptPet;
+import com.pawnder.entity.User;
+import com.pawnder.repository.AbandonedPetFormRepository;
+import com.pawnder.repository.AbandonedPetRepository;
+import com.pawnder.repository.AdoptPetRepository;
+import com.pawnder.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AdoptPetService {
+    private final UserRepository userRepository;
+    private final AbandonedPetRepository abandonedPetRepository;
+    private final AbandonedPetFormRepository abandonedPetFormRepository;
+    private final AdoptPetRepository adoptPetRepository;
+
+    // AdoptPetService
+    //유저 -> 입양 신청
+    public void applyAdoption(Long petId, String userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        AbandonedPet pet = abandonedPetRepository.findByAbandonedPetForm_Id(petId)
+                .orElseThrow(() -> new IllegalArgumentException("유기견 없음"));
+        AbandonedPetForm abandonedPetForm = abandonedPetFormRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("유기견 폼 없음"));
+
+        // 상태 변경
+        pet.setStatus(PetStatus.WAITING);
+        abandonedPetForm.setStatus(PetStatus.WAITING);
+
+        // AdoptPet 기록
+        AdoptPet adoptPet = new AdoptPet();
+        adoptPet.setUser(user);
+        adoptPet.setAbandonedPet(pet);
+        adoptPet.setAdoptStatus(AdoptStatus.REQUESTED);
+        adoptPet.setAppliedAt(LocalDateTime.now());
+        adoptPetRepository.save(adoptPet);
+    }
+
+    //관리자 -> 입양 승인
+    public void approveAdoption(Long adoptPetId) {
+        // 1. AdoptPet 조회
+        AdoptPet adoptPet = adoptPetRepository.findById(adoptPetId)
+                .orElseThrow(() -> new IllegalArgumentException("입양신청 없음"));
+
+        // 2. 해당 입양 신청에 연결된 유기견 조회
+        AbandonedPet pet = adoptPet.getAbandonedPet();
+        if (pet == null) throw new IllegalArgumentException("입양신청에 연결된 유기견 없음");
+
+        // 3. 유기견 폼 조회
+        AbandonedPetForm form = abandonedPetFormRepository.findById(pet.getAbandonedPetForm().getId())
+                .orElseThrow(() -> new IllegalArgumentException("유기견 폼 없음"));
+
+        // 4. 상태 변경
+        pet.setStatus(PetStatus.ADOPT);
+        form.setStatus(PetStatus.ADOPT);
+        adoptPet.setAdoptStatus(AdoptStatus.APPROVED);
+        adoptPet.setApprovedAt(LocalDateTime.now());
+    }
+
 
 }


### PR DESCRIPTION
### 📌 PR 개요
관리자가 입양 신청을 승인할 수 있는 기능을 구현했습니다.

---

### 🔨 작업 내용 요약
- 기능 추가: 입양 신청 승인 기능 구현 (`approveAdoption`)
- 수정: AdoptPet ID 기반으로 AbandonedPet, AbandonedPetForm 상태 변경
- 프론트 연동: 승인 버튼 클릭 시 adoptPetId 기반으로 승인 요청 전송

---

### ✅ 상세 구현 내용
- `approveAdoption(Long adoptPetId)` 메서드에서 AdoptPet ID를 기준으로 입양 신청을 조회
- 해당 입양 신청과 연관된 AbandonedPet 및 AbandonedPetForm 엔티티 상태를 `ADOPT`로 변경
- AdoptPet 상태는 `APPROVED`로 변경되며 승인 시각도 함께 기록
- 기존에 잘못된 `petId` 기반 로직 제거하고 올바른 관계 기반 처리 방식 적용
- React 프론트엔드에서 "승인" 버튼 클릭 시 `adoptPetId`가 서버로 전달되도록 연동 완료
